### PR TITLE
chore: add deprecation warning and update `package.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Expo Yarn Workspaces
 
+> ⚠️ This package has been deprecated and replaced with proper monorepo support starting from Expo SDK 49. [Learn more](https://docs.expo.dev/guides/monorepos/)
+
 This is a package that provides support for Yarn workspaces within monorepos like the Expo repository. It finesses Yarn workspaces, Metro, and the Expo repository to work together.
 
 **Note:** This package runs only on macOS and Linux.

--- a/package.json
+++ b/package.json
@@ -4,10 +4,8 @@
   "description": "A private package for working with Yarn workspaces within the Expo repository",
   "author": "Expo",
   "license": "MIT",
+  "bin": "bin/expo-yarn-workspaces.js",
   "main": "index.js",
-  "bin": {
-    "expo-yarn-workspaces": "./bin/expo-yarn-workspaces.js"
-  },
   "files": [
     "index.js",
     "webpack.js",
@@ -18,6 +16,14 @@
     "lint": "eslint .",
     "pretest": "cd workspace-template && yarn --no-lockfile",
     "test": "jest ."
+  },
+  "homepage": "https://github.com/expo/expo-yarn-workspaces#readme",
+  "bugs": {
+    "url": "https://github.com/expo/expo-yarn-workspaces/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/expo/expo-yarn-workspaces.git"
   },
   "dependencies": {
     "@expo/metro-config": "~0.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-yarn-workspaces",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "A private package for working with Yarn workspaces within the Expo repository",
   "author": "Expo",
   "license": "MIT",


### PR DESCRIPTION
Once PR stack expo/expo#25844 is fully merged, we can merge, publish, and deprecate this package.